### PR TITLE
Bring uap-scala up to date with uap-core

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "core"]
 	path = core
-	url = git@github.com:ua-parser/uap-core.git
+	url = https://github.com/ua-parser/uap-core.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,4 @@
 language: scala
 scala:
-   - 2.11.4
-# Handle git submodules yourself
-git:
-   submodules: false
-# Use sed to replace the SSH URL with the public URL, then initialize submodules
-before_install:
-   - sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
-   - git submodule update --init --recursive
+   - 2.11.7
+   - 2.10.5

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,9 @@ name := "uap-scala"
 
 version := "1.0-SNAPSHOT"
 
-scalaVersion := "2.11.4"
+scalaVersion := "2.11.7"
+
+crossScalaVersions := Seq("2.10.5", "2.11.7")
 
 libraryDependencies ++= Seq(
   "org.yaml" % "snakeyaml" % "1.10",

--- a/src/main/scala/ua/parser/OS.scala
+++ b/src/main/scala/ua/parser/OS.scala
@@ -12,7 +12,7 @@ object OS {
   }
 
   private[parser] case class OSPattern(pattern: Pattern, osReplacement: Option[String], v1Replacement: Option[String],
-                               v2Replacement: Option[String]) {
+                               v2Replacement: Option[String], v3Replacement: Option[String], v4Replacement: Option[String]) {
     def process(agent: String): Option[OS] = {
       val matcher = pattern.matcher(agent)
       if (!matcher.find()) return None
@@ -23,8 +23,8 @@ object OS {
       }.orElse(matcher.groupAt(1)).map { family =>
         val major = v1Replacement.orElse(matcher.groupAt(2))
         val minor = v2Replacement.orElse(matcher.groupAt(3))
-        val patch = matcher.groupAt(4)
-        val patchMinor = matcher.groupAt(5)
+        val patch = v3Replacement.orElse(matcher.groupAt(4))
+        val patchMinor = v4Replacement.orElse(matcher.groupAt(5))
         OS(family, major, minor, patch, patchMinor)
       }
     }
@@ -32,7 +32,8 @@ object OS {
 
   private object OSPattern {
     def fromMap(m: Map[String, String]) = m.get("regex").map { r =>
-      OSPattern(Pattern.compile(r), m.get("os_replacement"), m.get("os_v1_replacement"), m.get("os_v2_replacement"))
+      OSPattern(Pattern.compile(r), m.get("os_replacement"), m.get("os_v1_replacement"), m.get("os_v2_replacement"),
+        m.get("os_v3_replacement"), m.get("os_v4_replacement"))
     }
   }
 

--- a/src/main/scala/ua/parser/UserAgent.scala
+++ b/src/main/scala/ua/parser/UserAgent.scala
@@ -12,7 +12,8 @@ object UserAgent {
   }
 
   private[parser] case class UserAgentPattern(pattern: Pattern, familyReplacement: Option[String],
-                                      v1Replacement: Option[String], v2Replacement: Option[String]) {
+                                      v1Replacement: Option[String], v2Replacement: Option[String],
+                                      v3Replacement: Option[String]) {
     def process(agent: String): Option[UserAgent] = {
       val matcher = pattern.matcher(agent)
       if (!matcher.find()) return None
@@ -23,7 +24,7 @@ object UserAgent {
       }.orElse(matcher.groupAt(1)).map { family =>
         val major = v1Replacement.orElse(matcher.groupAt(2))
         val minor = v2Replacement.orElse(matcher.groupAt(3))
-        val patch = matcher.groupAt(4)
+        val patch = v3Replacement.orElse(matcher.groupAt(4))
         UserAgent(family, major, minor, patch)
       }
     }
@@ -32,7 +33,7 @@ object UserAgent {
   private object UserAgentPattern {
     def fromMap(config: Map[String, String]) = config.get("regex").map { r =>
       UserAgentPattern(Pattern.compile(r), config.get("family_replacement"), config.get("v1_replacement"),
-        config.get("v2_replacement"))
+        config.get("v2_replacement"), config.get("v3_replacement"))
     }
   }
 

--- a/src/test/scala/ua/parser/ParserSpecBase.scala
+++ b/src/test/scala/ua/parser/ParserSpecBase.scala
@@ -21,7 +21,7 @@ trait ParserSpecBase extends Specification {
         "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.4; fr; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5 ,gzip(gfe),gzip(gfe)" ->
           Client(UserAgent("Firefox", Some("3"), Some("5"), Some("5")), OS("Mac OS X", Some("10"), Some("4")), Device("Other")),
         "Mozilla/5.0 (iPhone; CPU iPhone OS 5_1_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9B206 Safari/7534.48.3" ->
-          Client(UserAgent("Mobile Safari", Some("5"), Some("1")), OS("iOS", Some("5"), Some("1"), Some("1")), Device("iPhone"))
+          Client(UserAgent("Mobile Safari", Some("5"), Some("1")), OS("iOS", Some("5"), Some("1"), Some("1")), Device("iPhone", Some("Apple"), Some("iPhone")))
       )
       cases.map { case (agent, expected) =>
         parser.parse(agent) must beEqualTo(expected)
@@ -65,13 +65,12 @@ trait ParserSpecBase extends Specification {
         }
       }.flatten
     }
-
     "properly parse device" in {
       readCasesConfig("/tests/test_device.yaml").map { c =>
         parser.parse(c("user_agent_string")).device must beEqualTo(Device.fromMap(c).get)
       }
     }
-
+    
     def readCasesConfig(resource: String) = {
       val stream = this.getClass.getResourceAsStream(resource)
       val cases = yaml.load(stream).asInstanceOf[JMap[String, JList[JMap[String, String]]]]


### PR DESCRIPTION
These changes updates uap-scala to use the latest version of uap-core. It also adds cross builds for different scala versions.

Build passes at https://travis-ci.org/humanzz/uap-scala