### PR TITLE
Scala 2.12 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: scala
 scala:
+  - 2.10.6
   - 2.11.11
 jdk:
   - openjdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,13 @@
 language: scala
 scala:
-   - 2.11.8
-   - 2.10.6
+  - 2.11.11
+jdk:
+  - openjdk7
+  - oraclejdk7
+  - oraclejdk8
+matrix:
+  include:
+  - scala: 2.12.2
+    jdk: oraclejdk8
+script:
+  - sbt ++$TRAVIS_SCALA_VERSION test

--- a/build.sbt
+++ b/build.sbt
@@ -4,14 +4,14 @@ organization := "org.uaparser"
 
 version := "0.1.0"
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.11.11"
 
-crossScalaVersions := Seq("2.10.6", "2.11.8")
+crossScalaVersions := Seq("2.11.11", "2.12.2")
 
 libraryDependencies ++= Seq(
-  "org.yaml" % "snakeyaml" % "1.10",
-  "com.twitter" %% "util-collection" % "6.23.0",
-  "org.specs2" %% "specs2-core" % "2.4.15" % "test"
+  "org.yaml" % "snakeyaml" % "1.18",
+  "com.twitter" %% "util-collection" % "6.43.0",
+  "org.specs2" %% "specs2-core" % "2.4.17" % "test"
 )
 
 unmanagedResourceDirectories in Compile += baseDirectory.value / "core"

--- a/build.sbt
+++ b/build.sbt
@@ -6,11 +6,10 @@ version := "0.1.0"
 
 scalaVersion := "2.11.11"
 
-crossScalaVersions := Seq("2.11.11", "2.12.2")
+crossScalaVersions := Seq("2.10.6", "2.11.11", "2.12.2")
 
 libraryDependencies ++= Seq(
   "org.yaml" % "snakeyaml" % "1.18",
-  "com.twitter" %% "util-collection" % "6.43.0",
   "org.specs2" %% "specs2-core" % "2.4.17" % "test"
 )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.12
+sbt.version=0.13.15


### PR DESCRIPTION
This PR adds Scala 2.12 support and updates the SnakeYAML version. It also removes the Twitter Util dependency by replacing the `LruMap` with a `LinkedHashMap`-based implementation. This is primarily because the latest Twitter Util releases don't support Scala 2.10, and also because Twitter Util is released relatively frequently, and the danger of running into incompatibilities seems greater than the inconvenience of defining a simple LRU cache from things in `java.util`.