### PR TITLE
Build additions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,8 @@ matrix:
   include:
   - scala: 2.12.2
     jdk: oraclejdk8
+install:
+  - pip install --user codecov
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION test
+  - sbt ++$TRAVIS_SCALA_VERSION clean coverage test coverageReport scalastyle;
+  - codecov

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
-uap-scala [![Build Status](https://travis-ci.org/ua-parser/uap-scala.png?branch=master)](https://travis-ci.org/ua-parser/uap-scala)
+uap-scala
 =========
+
+[![Build status](https://travis-ci.org/ua-parser/uap-scala.svg?branch=master)](https://travis-ci.org/ua-parser/uap-scala)
+[![Codecov status](https://codecov.io/gh/ua-parser/uap-scala/branch/master/graph/badge.svg)](https://codecov.io/gh/ua-parser/uap-scala)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.uaparser/uap-scala_2.11/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.uaparser/uap-scala_2.11)
 
 A Scala user-agent string parser based on [ua-parser/uap-core](https://github.com/ua-parser/uap-core). It extracts browser, OS and device information.
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,7 @@
 name := "uap-scala"
-
 organization := "org.uaparser"
 
-version := "0.1.0"
-
 scalaVersion := "2.11.11"
-
 crossScalaVersions := Seq("2.10.6", "2.11.11", "2.12.2")
 
 libraryDependencies ++= Seq(
@@ -13,12 +9,11 @@ libraryDependencies ++= Seq(
   "org.specs2" %% "specs2-core" % "2.4.17" % "test"
 )
 
+mimaPreviousArtifacts := Set("org.uaparser" %% "uap-scala" % "0.1.0")
+
 unmanagedResourceDirectories in Compile += baseDirectory.value / "core"
-
 includeFilter in (Compile, unmanagedResources) := "regexes.yaml"
-
 unmanagedResourceDirectories in Test += baseDirectory.value / "core"
-
 includeFilter in (Test, unmanagedResources) := "*.yaml"
 
 // Publishing

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,5 @@
+addSbtPlugin("com.github.gseitz"   % "sbt-release"           % "1.0.5")
+addSbtPlugin("com.jsuereth"        % "sbt-pgp"               % "1.0.1")
+addSbtPlugin("com.typesafe"        % "sbt-mima-plugin"       % "0.1.14")
+addSbtPlugin("org.scalastyle"     %% "scalastyle-sbt-plugin" % "0.8.0")
+addSbtPlugin("org.scoverage"       % "sbt-scoverage"         % "1.5.0")

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -1,0 +1,85 @@
+<scalastyle>
+    <name>uap-scala configuration</name>
+    <check level="error" class="org.scalastyle.scalariform.EnsureSingleSpaceAfterTokenChecker" enabled="true">
+        <parameters>
+            <parameter name="tokens">FOR</parameter>
+            <parameter name="tokens">IF</parameter>
+        </parameters>
+    </check>
+    <check level="error" class="org.scalastyle.file.FileTabChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.file.FileLengthChecker" enabled="true">
+        <parameters>
+            <parameter name="maxFileLength"><![CDATA[800]]></parameter>
+        </parameters>
+    </check>
+    <check level="error" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
+        <parameters>
+            <parameter name="maxLineLength"><![CDATA[120]]></parameter>
+        </parameters>
+    </check>
+    <check level="error" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check>
+    <check level="error" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[[A-Z\~\*\/][A-Za-z]*]]></parameter>
+        </parameters>
+    </check>
+    <check level="error" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[[A-Za-z\~\*\/][A-Za-z]*]]></parameter>
+        </parameters>
+    </check>
+    <check level="error" class="org.scalastyle.scalariform.PackageObjectNamesChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[^[a-z][a-z0-9]*$]]></parameter>
+        </parameters>
+    </check>
+    <check level="error" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>
+    <check level="error" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
+        <parameters>
+            <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter>
+        </parameters>
+    </check>
+    <check level="error" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"></check>
+    <check level="error" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="true"></check>
+    <check level="error" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"></check>
+    <check level="error" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check>
+    <check level="error" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>
+    <check level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[println]]></parameter>
+        </parameters>
+    </check>
+    <check level="error" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true">
+        <parameters>
+            <parameter name="maxTypes"><![CDATA[70]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="true">
+        <parameters>
+            <parameter name="maximum"><![CDATA[20]]></parameter>
+        </parameters>
+    </check>
+    <check level="error" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
+    <check level="error" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
+        <parameters>
+            <parameter name="maxLength"><![CDATA[50]]></parameter>
+        </parameters>
+    </check>
+    <check level="error" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
+    <check level="error" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check>
+    <check level="error" class="org.scalastyle.scalariform.NotImplementedErrorUsage" enabled="true"></check>
+    <check level="error" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true">
+        <parameters>
+            <parameter name="ignoreOverride">true</parameter>
+        </parameters>
+    </check>
+    <check level="error" enabled="true" class="org.scalastyle.scalariform.ImportOrderChecker">
+        <parameters>
+            <parameter name="groups">all</parameter>
+            <parameter name="group.all">.+</parameter>
+        </parameters>
+    </check>
+</scalastyle>

--- a/src/main/scala/org/uaparser/scala/CachingParser.scala
+++ b/src/main/scala/org/uaparser/scala/CachingParser.scala
@@ -4,13 +4,13 @@ import java.io.InputStream
 import java.util.{ Collections, LinkedHashMap, Map => JMap }
 
 case class CachingParser(parser: Parser, maxEntries: Int) extends UserAgentStringParser {
-  lazy val clients = Collections.synchronizedMap(
+  lazy val clients: JMap[String, Client] = Collections.synchronizedMap(
     new LinkedHashMap[String, Client](maxEntries + 1, 1.0f, true) {
       override protected def removeEldestEntry(eldest: JMap.Entry[String, Client]): Boolean =
         super.size > maxEntries
     }
   )
-  def parse(agent: String) = Option(clients.get(agent)).getOrElse {
+  def parse(agent: String): Client = Option(clients.get(agent)).getOrElse {
     val client = parser.parse(agent)
     clients.put(agent, client)
     client
@@ -18,7 +18,8 @@ case class CachingParser(parser: Parser, maxEntries: Int) extends UserAgentStrin
 }
 
 object CachingParser {
-  val defaultCacheSize = 1000
-  def create(source: InputStream, size: Int = defaultCacheSize) = CachingParser(Parser.create(source), size)
-  def get(size: Int = defaultCacheSize) = CachingParser(Parser.get, size)
+  val defaultCacheSize: Int = 1000
+  def create(source: InputStream, size: Int = defaultCacheSize): CachingParser =
+    CachingParser(Parser.create(source), size)
+  def get(size: Int = defaultCacheSize): CachingParser = CachingParser(Parser.get, size)
 }

--- a/src/main/scala/org/uaparser/scala/Device.scala
+++ b/src/main/scala/org/uaparser/scala/Device.scala
@@ -1,7 +1,6 @@
 package org.uaparser.scala
 
-import java.util.regex.{Matcher, Pattern}
-
+import java.util.regex.{ Matcher, Pattern }
 import org.uaparser.scala.MatcherOps._
 
 case class Device(family: String, brand: Option[String] = None, model: Option[String] = None)
@@ -13,17 +12,18 @@ object Device {
                                            brandReplacement: Option[String], modelReplacement: Option[String]) {
     def process(agent: String): Option[Device] = {
       val matcher = pattern.matcher(agent)
-      if (!matcher.find()) return None
-      val family = familyReplacement.map(r => replace(r, matcher)).orElse(matcher.groupAt(1))
-      val brand = brandReplacement.map(r => replace(r, matcher)).filterNot(s => s.isEmpty)
-      val model = modelReplacement.map(r => replace(r, matcher)).orElse(matcher.groupAt(1)).filterNot(s => s.isEmpty)
-      family.map(Device(_, brand, model))
+      if (!matcher.find()) None else {
+        val family = familyReplacement.map(r => replace(r, matcher)).orElse(matcher.groupAt(1))
+        val brand = brandReplacement.map(r => replace(r, matcher)).filterNot(s => s.isEmpty)
+        val model = modelReplacement.map(r => replace(r, matcher)).orElse(matcher.groupAt(1)).filterNot(s => s.isEmpty)
+        family.map(Device(_, brand, model))
+      }
     }
 
-    def replace(replacement: String, matcher: Matcher) = {
+    def replace(replacement: String, matcher: Matcher): String = {
       (if (replacement.contains("$") && matcher.groupCount() >= 1)  {
         (1 to matcher.groupCount()).foldLeft(replacement)((rep, i) => {
-          val toInsert = if(matcher.group(i) != null) matcher.group(i) else ""
+          val toInsert = if (matcher.group(i) ne null) matcher.group(i) else ""
           rep.replaceFirst("\\$" + i, Matcher.quoteReplacement(toInsert))
         })
       } else replacement).trim
@@ -31,20 +31,23 @@ object Device {
   }
 
   private object DevicePattern {
-    def fromMap(m: Map[String, String]) = m.get("regex").map { r =>
-      val pattern = m.get("regex_flag").map(flag => Pattern.compile(r, Pattern.CASE_INSENSITIVE)).getOrElse(Pattern.compile(r))
+    def fromMap(m: Map[String, String]): Option[DevicePattern] = m.get("regex").map { r =>
+      val pattern = m.get("regex_flag").map(flag =>
+        Pattern.compile(r, Pattern.CASE_INSENSITIVE)).getOrElse(Pattern.compile(r)
+      )
       DevicePattern(pattern, m.get("device_replacement"), m.get("brand_replacement"), m.get("model_replacement"))
     }
   }
 
   case class DeviceParser(patterns: List[DevicePattern]) {
-    def parse(agent: String) = patterns.foldLeft[Option[Device]](None) {
+    def parse(agent: String): Device = patterns.foldLeft[Option[Device]](None) {
       case (None, pattern) => pattern.process(agent)
       case (result, _) => result
     }.getOrElse(Device("Other"))
   }
 
   object DeviceParser {
-    def fromList(config: List[Map[String, String]]) = DeviceParser(config.map(DevicePattern.fromMap).flatten)
+    def fromList(config: List[Map[String, String]]): DeviceParser =
+      DeviceParser(config.map(DevicePattern.fromMap).flatten)
   }
 }

--- a/src/main/scala/org/uaparser/scala/MatcherOps.scala
+++ b/src/main/scala/org/uaparser/scala/MatcherOps.scala
@@ -5,6 +5,6 @@ import java.util.regex.Matcher
 object MatcherOps {
   implicit class MatcherImprovements(val m: Matcher) {
     import scala.util.control.Exception._
-    def groupAt(i: Int) = catching(classOf[IndexOutOfBoundsException]).opt(Option(m.group(i))).flatten
+    def groupAt(i: Int): Option[String] = catching(classOf[IndexOutOfBoundsException]).opt(Option(m.group(i))).flatten
   }
 }

--- a/src/main/scala/org/uaparser/scala/OS.scala
+++ b/src/main/scala/org/uaparser/scala/OS.scala
@@ -11,40 +11,47 @@ object OS {
     OS(family, m.get("major"), m.get("minor"), m.get("patch"), m.get("patch_minor"))
   }
 
-  private[scala] case class OSPattern(pattern: Pattern, osReplacement: Option[String], v1Replacement: Option[String],
-                               v2Replacement: Option[String], v3Replacement: Option[String], v4Replacement: Option[String]) {
+  private[scala] case class OSPattern(
+    pattern: Pattern,
+    osReplacement: Option[String],
+    v1Replacement: Option[String],
+    v2Replacement: Option[String],
+    v3Replacement: Option[String],
+    v4Replacement: Option[String]
+  ) {
     def process(agent: String): Option[OS] = {
       val matcher = pattern.matcher(agent)
-      if (!matcher.find()) return None
-      osReplacement.map { replacement =>
-        if (matcher.groupCount() >= 1)
-          Pattern.compile(s"(${Pattern.quote("$1")})").matcher(replacement).replaceAll(matcher.group(1))
-        else replacement
-      }.orElse(matcher.groupAt(1)).map { family =>
-        val major = v1Replacement.orElse(matcher.groupAt(2))
-        val minor = v2Replacement.orElse(matcher.groupAt(3))
-        val patch = v3Replacement.orElse(matcher.groupAt(4))
-        val patchMinor = v4Replacement.orElse(matcher.groupAt(5))
-        OS(family, major, minor, patch, patchMinor)
+      if (!matcher.find()) None else {
+        osReplacement.map { replacement =>
+          if (matcher.groupCount() >= 1)
+            Pattern.compile(s"(${Pattern.quote("$1")})").matcher(replacement).replaceAll(matcher.group(1))
+          else replacement
+        }.orElse(matcher.groupAt(1)).map { family =>
+          val major = v1Replacement.orElse(matcher.groupAt(2))
+          val minor = v2Replacement.orElse(matcher.groupAt(3))
+          val patch = v3Replacement.orElse(matcher.groupAt(4))
+          val patchMinor = v4Replacement.orElse(matcher.groupAt(5))
+          OS(family, major, minor, patch, patchMinor)
+        }
       }
     }
   }
 
   private object OSPattern {
-    def fromMap(m: Map[String, String]) = m.get("regex").map { r =>
+    def fromMap(m: Map[String, String]): Option[OSPattern] = m.get("regex").map { r =>
       OSPattern(Pattern.compile(r), m.get("os_replacement"), m.get("os_v1_replacement"), m.get("os_v2_replacement"),
         m.get("os_v3_replacement"), m.get("os_v4_replacement"))
     }
   }
 
   case class OSParser(patterns: List[OSPattern]) {
-    def parse(agent: String) = patterns.foldLeft[Option[OS]](None) {
+    def parse(agent: String): OS = patterns.foldLeft[Option[OS]](None) {
       case (None, pattern) => pattern.process(agent)
       case (result, _) => result
     }.getOrElse(OS("Other"))
   }
 
   object OSParser {
-    def fromList(config: List[Map[String, String]]) = OSParser(config.map(OSPattern.fromMap).flatten)
+    def fromList(config: List[Map[String, String]]): OSParser = OSParser(config.map(OSPattern.fromMap).flatten)
   }
 }

--- a/src/main/scala/org/uaparser/scala/Parser.scala
+++ b/src/main/scala/org/uaparser/scala/Parser.scala
@@ -1,32 +1,31 @@
 package org.uaparser.scala
 
 import java.io.InputStream
-import java.util.{List => JList, Map => JMap}
-
+import java.util.{ List => JList, Map => JMap }
 import org.uaparser.scala.Device.DeviceParser
 import org.uaparser.scala.OS.OSParser
 import org.uaparser.scala.UserAgent.UserAgentParser
 import org.yaml.snakeyaml.Yaml
 import org.yaml.snakeyaml.constructor.SafeConstructor
-
 import scala.collection.JavaConverters._
 
 case class Parser(userAgentParser: UserAgentParser, osParser: OSParser, deviceParser: DeviceParser)
     extends UserAgentStringParser {
-  def parse(agent: String) = Client(userAgentParser.parse(agent), osParser.parse(agent), deviceParser.parse(agent))
+  def parse(agent: String): Client =
+    Client(userAgentParser.parse(agent), osParser.parse(agent), deviceParser.parse(agent))
 }
 
 object Parser {
-  def create(source: InputStream) = {
+  def create(source: InputStream): Parser = {
     val yaml = new Yaml(new SafeConstructor)
     val javaConfig = yaml.load(source).asInstanceOf[JMap[String, JList[JMap[String, String]]]]
     val config = javaConfig.asScala.toMap.mapValues(_.asScala.toList.map(_.asScala.toMap.filterNot {
-      case (_ , value) => value == null
+      case (_ , value) => value eq null
     }))
-    val userAgentParser = UserAgentParser.fromList(config.getOrElse("user_agent_parsers", List()))
-    val osParser = OSParser.fromList(config.getOrElse("os_parsers", List()))
-    val deviceParser = DeviceParser.fromList(config.getOrElse("device_parsers", List()))
+    val userAgentParser = UserAgentParser.fromList(config.getOrElse("user_agent_parsers", Nil))
+    val osParser = OSParser.fromList(config.getOrElse("os_parsers", Nil))
+    val deviceParser = DeviceParser.fromList(config.getOrElse("device_parsers", Nil))
     Parser(userAgentParser, osParser, deviceParser)
   }
-  def get = create(this.getClass.getResourceAsStream("/regexes.yaml"))
+  def get: Parser = create(this.getClass.getResourceAsStream("/regexes.yaml"))
 }

--- a/src/main/scala/org/uaparser/scala/UserAgent.scala
+++ b/src/main/scala/org/uaparser/scala/UserAgent.scala
@@ -31,20 +31,21 @@ object UserAgent {
   }
 
   private object UserAgentPattern {
-    def fromMap(config: Map[String, String]) = config.get("regex").map { r =>
+    def fromMap(config: Map[String, String]): Option[UserAgentPattern] = config.get("regex").map { r =>
       UserAgentPattern(Pattern.compile(r), config.get("family_replacement"), config.get("v1_replacement"),
         config.get("v2_replacement"), config.get("v3_replacement"))
     }
   }
 
   case class UserAgentParser(patterns: List[UserAgentPattern]) {
-    def parse(agent: String) = patterns.foldLeft[Option[UserAgent]](None) {
+    def parse(agent: String): UserAgent = patterns.foldLeft[Option[UserAgent]](None) {
       case (None, pattern) => pattern.process(agent)
       case (result, _) => result
     }.getOrElse(UserAgent("Other"))
   }
 
   object UserAgentParser {
-    def fromList(config: List[Map[String, String]]) = UserAgentParser(config.map(UserAgentPattern.fromMap).flatten)
+    def fromList(config: List[Map[String, String]]): UserAgentParser =
+      UserAgentParser(config.map(UserAgentPattern.fromMap).flatten)
   }
 }

--- a/src/test/scala/org/uaparser/scala/CachingParserSpec.scala
+++ b/src/test/scala/org/uaparser/scala/CachingParserSpec.scala
@@ -1,5 +1,8 @@
 package org.uaparser.scala
 
+import java.io.InputStream
+
 class CachingParserSpec extends ParserSpecBase {
   val parser = CachingParser.get()
+  def createFromStream(stream: InputStream): UserAgentStringParser = CachingParser.create(stream)
 }

--- a/src/test/scala/org/uaparser/scala/ParserSpec.scala
+++ b/src/test/scala/org/uaparser/scala/ParserSpec.scala
@@ -1,5 +1,8 @@
 package org.uaparser.scala
 
+import java.io.InputStream
+
 class ParserSpec extends ParserSpecBase {
   val parser = Parser.get
+  def createFromStream(stream: InputStream): UserAgentStringParser = Parser.create(stream)
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "0.2.0-SNAPSHOT"


### PR DESCRIPTION
This is in preparation for an 0.2.0 release. I've added several SBT plugins to make maintenance a little easier, including sbt-release, Scalastyle, and coverage reporting.

I've made a few changes to the code, but these are only to keep Scalastyle happy (explicit type annotations for public methods, rearranged imports, etc.) and to get test coverage up to 100%.

I've also added MiMa binary compatibility checking—you can run `sbt mimaReportBinaryIssues` to identify binary incompatibilities between your local changes and the published version listed in `mimaPreviousArtifacts` (in this case the 2.12 artifact will be compatible with this branch, but not the 2.10 or 2.11 ones, since those still used util-collection).

/cc @jleider