### PR TITLE
Minor renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ version: 0.1.0
 import org.uaparser.scala.Parser
 
 val ua = "Mozilla/5.0 (iPhone; CPU iPhone OS 5_1_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9B206 Safari/7534.48.3"
-val client = Parser.get.parse(ua) // you can also use CachingParser
+val client = Parser.default.parse(ua) // you can also use CachingParser
 println(client) // Client(UserAgent(Mobile Safari,Some(5),Some(1),None),OS(iOS,Some(5),Some(1),Some(1),None),Device(iPhone))
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,17 @@
 name := "uap-scala"
 organization := "org.uaparser"
 
+scalacOptions ++= Seq(
+  "-deprecation",
+  "-encoding", "UTF-8",
+  "-feature",
+  "-unchecked",
+  "-Yno-adapted-args",
+  "-Ywarn-dead-code",
+  "-Ywarn-numeric-widen",
+  "-Xfuture"
+)
+
 scalaVersion := "2.11.11"
 crossScalaVersions := Seq("2.10.6", "2.11.11", "2.12.2")
 

--- a/src/main/scala/org/uaparser/scala/CachingParser.scala
+++ b/src/main/scala/org/uaparser/scala/CachingParser.scala
@@ -20,12 +20,12 @@ case class CachingParser(parser: Parser, maxEntries: Int) extends UserAgentStrin
 
 object CachingParser {
   val defaultCacheSize: Int = 1000
-  def fromStream(source: InputStream, size: Int = defaultCacheSize): Try[CachingParser] =
-    Parser.fromStream(source).map(CachingParser(_, size))
+  def fromInputStream(source: InputStream, size: Int = defaultCacheSize): Try[CachingParser] =
+    Parser.fromInputStream(source).map(CachingParser(_, size))
   def default(size: Int = defaultCacheSize): CachingParser = CachingParser(Parser.default, size)
 
-  @deprecated("use fromStream", "0.2.0")
-  def create(source: InputStream, size: Int = defaultCacheSize): CachingParser = fromStream(source, size).get
+  @deprecated("use fromInputStream", "0.2.0")
+  def create(source: InputStream, size: Int = defaultCacheSize): CachingParser = fromInputStream(source, size).get
 
   @deprecated("use default", "0.2.0")
   def get(size: Int = defaultCacheSize): CachingParser = default(size)

--- a/src/main/scala/org/uaparser/scala/CachingParser.scala
+++ b/src/main/scala/org/uaparser/scala/CachingParser.scala
@@ -2,6 +2,7 @@ package org.uaparser.scala
 
 import java.io.InputStream
 import java.util.{ Collections, LinkedHashMap, Map => JMap }
+import scala.util.Try
 
 case class CachingParser(parser: Parser, maxEntries: Int) extends UserAgentStringParser {
   lazy val clients: JMap[String, Client] = Collections.synchronizedMap(
@@ -19,7 +20,13 @@ case class CachingParser(parser: Parser, maxEntries: Int) extends UserAgentStrin
 
 object CachingParser {
   val defaultCacheSize: Int = 1000
-  def create(source: InputStream, size: Int = defaultCacheSize): CachingParser =
-    CachingParser(Parser.create(source), size)
-  def get(size: Int = defaultCacheSize): CachingParser = CachingParser(Parser.get, size)
+  def fromStream(source: InputStream, size: Int = defaultCacheSize): Try[CachingParser] =
+    Parser.fromStream(source).map(CachingParser(_, size))
+  def default(size: Int = defaultCacheSize): CachingParser = CachingParser(Parser.default, size)
+
+  @deprecated("use fromStream", "0.2.0")
+  def create(source: InputStream, size: Int = defaultCacheSize): CachingParser = fromStream(source, size).get
+
+  @deprecated("use default", "0.2.0")
+  def get(size: Int = defaultCacheSize): CachingParser = default(size)
 }

--- a/src/main/scala/org/uaparser/scala/Parser.scala
+++ b/src/main/scala/org/uaparser/scala/Parser.scala
@@ -17,7 +17,7 @@ case class Parser(userAgentParser: UserAgentParser, osParser: OSParser, devicePa
 }
 
 object Parser {
-  def fromStream(source: InputStream): Try[Parser] = Try {
+  def fromInputStream(source: InputStream): Try[Parser] = Try {
     val yaml = new Yaml(new SafeConstructor)
     val javaConfig = yaml.load(source).asInstanceOf[JMap[String, JList[JMap[String, String]]]]
     val config = javaConfig.asScala.toMap.mapValues(_.asScala.toList.map(_.asScala.toMap.filterNot {
@@ -28,10 +28,10 @@ object Parser {
     val deviceParser = DeviceParser.fromList(config.getOrElse("device_parsers", Nil))
     Parser(userAgentParser, osParser, deviceParser)
   }
-  def default: Parser = fromStream(this.getClass.getResourceAsStream("/regexes.yaml")).get
+  def default: Parser = fromInputStream(this.getClass.getResourceAsStream("/regexes.yaml")).get
 
-  @deprecated("use fromStream", "0.2.0")
-  def create(source: InputStream): Parser = fromStream(source).get
+  @deprecated("use fromInputStream", "0.2.0")
+  def create(source: InputStream): Parser = fromInputStream(source).get
 
   @deprecated("use default", "0.2.0")
   def get: Parser = default

--- a/src/main/scala/org/uaparser/scala/Parser.scala
+++ b/src/main/scala/org/uaparser/scala/Parser.scala
@@ -8,6 +8,7 @@ import org.uaparser.scala.UserAgent.UserAgentParser
 import org.yaml.snakeyaml.Yaml
 import org.yaml.snakeyaml.constructor.SafeConstructor
 import scala.collection.JavaConverters._
+import scala.util.Try
 
 case class Parser(userAgentParser: UserAgentParser, osParser: OSParser, deviceParser: DeviceParser)
     extends UserAgentStringParser {
@@ -16,7 +17,7 @@ case class Parser(userAgentParser: UserAgentParser, osParser: OSParser, devicePa
 }
 
 object Parser {
-  def create(source: InputStream): Parser = {
+  def fromStream(source: InputStream): Try[Parser] = Try {
     val yaml = new Yaml(new SafeConstructor)
     val javaConfig = yaml.load(source).asInstanceOf[JMap[String, JList[JMap[String, String]]]]
     val config = javaConfig.asScala.toMap.mapValues(_.asScala.toList.map(_.asScala.toMap.filterNot {
@@ -27,5 +28,11 @@ object Parser {
     val deviceParser = DeviceParser.fromList(config.getOrElse("device_parsers", Nil))
     Parser(userAgentParser, osParser, deviceParser)
   }
-  def get: Parser = create(this.getClass.getResourceAsStream("/regexes.yaml"))
+  def default: Parser = fromStream(this.getClass.getResourceAsStream("/regexes.yaml")).get
+
+  @deprecated("use fromStream", "0.2.0")
+  def create(source: InputStream): Parser = fromStream(source).get
+
+  @deprecated("use default", "0.2.0")
+  def get: Parser = default
 }


### PR DESCRIPTION
I'd like to suggest changing a couple of things in the `Parser` API:

1. Rename `get` to `default`.
2. Rename `create` to `fromStream` and make it safe via `Try`, since the user's loading arbitrary stuff and the YAML parsing may throw an exception.

This is super nitpicky but I feel like `get` generally means something else in Scala APIs and both methods `create` an instance.

I've deprecated the old names and will plan to remove them after 0.2.0 if this gets merged. (I've left them  in use in the tests for now to keep code coverage intact, but will change that after 0.2.0.)