### PR TITLE
Update uap-core version to latest and replace back references at os version

### DIFF
--- a/src/main/scala/org/uaparser/scala/OS.scala
+++ b/src/main/scala/org/uaparser/scala/OS.scala
@@ -32,16 +32,20 @@ object OS {
         osReplacement
           .map(replacementBack1(matcher))
           .orElse(matcher.groupAt(1)).map { family =>
-            val major = v1Replacement
-              .map(replacementBack1(matcher))
-              .orElse(matcher.groupAt(2))
-            val minor = v2Replacement.orElse(matcher.groupAt(3))
-            val patch = v3Replacement.orElse(matcher.groupAt(4))
-            val patchMinor = v4Replacement.orElse(matcher.groupAt(5))
+            val major = v1Replacement.flatMap(replace(matcher)).orElse(matcher.groupAt(2))
+            val minor = v2Replacement.flatMap(replace(matcher)).orElse(matcher.groupAt(3))
+            val patch = v3Replacement.flatMap(replace(matcher)).orElse(matcher.groupAt(4))
+            val patchMinor = v4Replacement.flatMap(replace(matcher)).orElse(matcher.groupAt(5))
             OS(family, major, minor, patch, patchMinor)
         }
       }
     }
+
+    private def replace(matcher: Matcher)(replacement: String): Option[String] =
+      if (replacement.contains("$")) { // is a backreference (i.e. $1, $2, $3, $4, etc)
+        val group: Int = replacement.substring(1).toInt
+        matcher.groupAt(group)
+      } else Some(replacement)
   }
 
   private object OSPattern {

--- a/src/main/scala/org/uaparser/scala/OS.scala
+++ b/src/main/scala/org/uaparser/scala/OS.scala
@@ -18,6 +18,12 @@ object OS {
       quotedBack1.matcher(replacement).replaceAll(matcher.group(1))
     } else replacement
 
+  private[this] def replaceBackreference(matcher: Matcher)(replacement: String): Option[String] =
+    if (replacement.contains("$")) { // is a backreference (i.e. $1, $2, $3, $4, etc)
+      val group: Int = replacement.substring(1).toInt
+      matcher.groupAt(group)
+    } else Some(replacement)
+
   private[scala] case class OSPattern(
     pattern: Pattern,
     osReplacement: Option[String],
@@ -32,20 +38,14 @@ object OS {
         osReplacement
           .map(replacementBack1(matcher))
           .orElse(matcher.groupAt(1)).map { family =>
-            val major = v1Replacement.flatMap(replace(matcher)).orElse(matcher.groupAt(2))
-            val minor = v2Replacement.flatMap(replace(matcher)).orElse(matcher.groupAt(3))
-            val patch = v3Replacement.flatMap(replace(matcher)).orElse(matcher.groupAt(4))
-            val patchMinor = v4Replacement.flatMap(replace(matcher)).orElse(matcher.groupAt(5))
+            val major = v1Replacement.flatMap(replaceBackreference(matcher)).orElse(matcher.groupAt(2))
+            val minor = v2Replacement.flatMap(replaceBackreference(matcher)).orElse(matcher.groupAt(3))
+            val patch = v3Replacement.flatMap(replaceBackreference(matcher)).orElse(matcher.groupAt(4))
+            val patchMinor = v4Replacement.flatMap(replaceBackreference(matcher)).orElse(matcher.groupAt(5))
             OS(family, major, minor, patch, patchMinor)
         }
       }
     }
-
-    private def replace(matcher: Matcher)(replacement: String): Option[String] =
-      if (replacement.contains("$")) { // is a backreference (i.e. $1, $2, $3, $4, etc)
-        val group: Int = replacement.substring(1).toInt
-        matcher.groupAt(group)
-      } else Some(replacement)
   }
 
   private object OSPattern {

--- a/src/test/scala/org/uaparser/scala/ParserSpecBase.scala
+++ b/src/test/scala/org/uaparser/scala/ParserSpecBase.scala
@@ -58,6 +58,26 @@ trait ParserSpecBase extends Specification {
       client.device.family must beEqualTo("CashPhone $9")
     }
 
+    "properly quote all os replacements" >> {
+      val testConfig =
+        """
+          |os_parsers:
+          |  - regex: '(\w+\s+Mac OS X\s+\w+\s+(\d+).(\d+).(\d+).*)'
+          |    os_replacement: 'Mac OS X'
+          |    os_v1_replacement: '$2'
+          |    os_v2_replacement: '$3'
+          |    os_v3_replacement: '$4'
+        """.stripMargin
+
+      val stream = new ByteArrayInputStream(testConfig.getBytes(StandardCharsets.UTF_8))
+      val parser = createFromStream(stream)
+      val client = parser.parse("""ABC12\34 (Intelx64 Mac OS X Version 10.12.6 OH-HAI=/^.^\=)""")
+      client.os.family must beEqualTo("Mac OS X")
+      client.os.major must beSome("10")
+      client.os.minor must beSome("12")
+      client.os.patch must beSome("6")
+    }
+
     "properly handle empty config" >> {
       val stream = new ByteArrayInputStream("{}".getBytes(StandardCharsets.UTF_8))
       val parser = createFromStream(stream)


### PR DESCRIPTION
I make some changes as follows:
- According to [OS Parser implementation note](https://github.com/ua-parser/uap-core/blob/master/docs/specification.md#os_parsers), when os_{v1,v2,v3,v4}_replacement contain back reference (i.e. $2, $3, etc), the back references should be replaced by the matched.
- Update uap-core to [latest version](https://github.com/ua-parser/uap-core/commit/23bfabe34b86f29f4840c9dd1ef6129e685581e3)