### PR TITLE
Update core to 6cfb9157

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.7
+sbt.version=1.2.8

--- a/src/main/scala/org/uaparser/scala/UserAgent.scala
+++ b/src/main/scala/org/uaparser/scala/UserAgent.scala
@@ -22,9 +22,9 @@ object UserAgent {
           replacement.replaceFirst("\\$1", Matcher.quoteReplacement(matcher.group(1)))
         } else replacement
       }.orElse(matcher.groupAt(1)).map { family =>
-        val major = v1Replacement.orElse(matcher.groupAt(2))
-        val minor = v2Replacement.orElse(matcher.groupAt(3))
-        val patch = v3Replacement.orElse(matcher.groupAt(4))
+        val major = v1Replacement.orElse(matcher.groupAt(2)).filter(_.nonEmpty)
+        val minor = v2Replacement.orElse(matcher.groupAt(3)).filter(_.nonEmpty)
+        val patch = v3Replacement.orElse(matcher.groupAt(4)).filter(_.nonEmpty)
         UserAgent(family, major, minor, patch)
       }
     }

--- a/src/test/scala/org/uaparser/scala/ParserSpecBase.scala
+++ b/src/test/scala/org/uaparser/scala/ParserSpecBase.scala
@@ -87,6 +87,21 @@ trait ParserSpecBase extends Specification {
       client.device.family must beEqualTo("Other")
     }
 
+    "properly parse an user agent with None for missing information" >> {
+      val testConfig =
+        """
+          |user_agent_parsers:
+          |  - regex: '(ABC) (\d+?\.|)(\d+|)(\d+|);'
+        """.stripMargin
+      val stream = new ByteArrayInputStream(testConfig.getBytes(StandardCharsets.UTF_8))
+      val parser = createFromStream(stream)
+      val client = parser.parse("""(compatible; ABC ; OH-HAI=/^.^\=""")
+      client.userAgent.family must beEqualTo("ABC")
+      client.userAgent.major must beNone
+      client.userAgent.minor must beNone
+      client.userAgent.patch must beNone
+    }
+
     "properly parse user agents" >> {
       List("/tests/test_ua.yaml", "/test_resources/firefox_user_agent_strings.yaml",
         "/test_resources/pgts_browser_list.yaml").map { file =>


### PR DESCRIPTION
Update uap-core to 6cfb9157 (Diff is [here](https://github.com/ua-parser/uap-core/compare/4e97f111af71597d038eff1730fb8d7e4f4e7ae4...6cfb915779a6b707b4f622cc1ebb70c15000bfb2)) and bump sbt version to 1.2.8

Also, fix the following: 
Convert `Some` of an empty string to `None` at User-Agent version's major, minor, patch by adding `filter(_.nonEmpty)` condition.

The major, minor or patch cloud become an empty string when regular-expression contains matching expressions but the `{v1,v2,v3}_replacement` are not defined. 

For example, with following config:
```yaml
user_agent_parsers:
  - regex: '(MSIE) (\d+)\.(\d+)([a-z]\d|[a-z]|);.* MSIECrawler'
```

The version patch information of following User-Agent string is empty string
```scala
val ua = "Mozilla/4.0 (compatible; MSIE 4.0; MSIECrawler; Windows 95)"

import  java.util.regex.Pattern
val pattern = Pattern.compile(raw"(MSIE) (\d+)\.(\d+)([a-z]\d|[a-z]|);.* MSIECrawler")
val matcher = pattern.matcher(ua)

matcher.find() // return true
matcher.groupCount() // return 4

matcher.group(1) // return "MISE", family info
matcher.group(2) // return "4", version major info
matcher.group(3) // return "0", version minor info
matcher.group(4) // return "", version patch info
```