### PR TITLE
Update version pointers in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,21 +40,28 @@ Scala 2.10
 ```
 groupId: org.uaparser
 artifactId: uap-scala_2.10
-version: 0.3.0
+version: 0.11.0
 ```
 
 Scala 2.11
 ```
 groupId: org.uaparser
 artifactId: uap-scala_2.11
-version: 0.3.0
+version: 0.11.0
 ```
 
 Scala 2.12
 ```
 groupId: org.uaparser
 artifactId: uap-scala_2.12
-version: 0.3.0
+version: 0.11.0
+```
+
+Scala 2.13
+```
+groupId: org.uaparser
+artifactId: uap-scala_2.13
+version: 0.11.0
 ```
 
 ### Usage


### PR DESCRIPTION
This PR just adds a new section pointing to scala 2.13 and updates the library versions pointed to in README.md.