### PR TITLE
Adds warning to README to make it clearer to users Parser/Parser.default are expensive

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ version: 0.11.0
 ```
 
 ### Usage
+
+#### Note about these examples
+Instantiating Parser.default also instantiates secondary classes and reads in YAML files. This is slow.
+If performance is critical or you are handling user agents in real time, be sure not to do this on the
+critical path for processing requests.
+
 #### Retrieve data on a user-agent string
 ```scala
 import org.uaparser.scala.Parser


### PR DESCRIPTION
This parsing code takes a fair bit of memory to set up, and Parser.default contains a YAML file read which is fairly expensive and should not be done multiple times if it can be avoided. Parser.default is ideal for instantiation in a package object or somewhere else reusable and easily accessible. Having shot myself in the foot with this, I'd like to leave a note for others. 

I was attempting to use this library as a replacement for Bitwalker UserAgentUtils which are EOL'd but significantly faster and less resource hungry than uap, even with Parser.default instantiated once per server. I would love to be able to use this library but it's not performant enough for my use case. If folks are amenable I may try to add optimisations?