### PR TITLE
Minor changes to remove some compiler and editor warnings

### DIFF
--- a/src/main/scala/org/uaparser/scala/Device.scala
+++ b/src/main/scala/org/uaparser/scala/Device.scala
@@ -48,6 +48,6 @@ object Device {
 
   object DeviceParser {
     def fromList(config: List[Map[String, String]]): DeviceParser =
-      DeviceParser(config.map(DevicePattern.fromMap).flatten)
+      DeviceParser(config.flatMap(DevicePattern.fromMap))
   }
 }

--- a/src/main/scala/org/uaparser/scala/OS.scala
+++ b/src/main/scala/org/uaparser/scala/OS.scala
@@ -72,6 +72,6 @@ object OS {
   }
 
   object OSParser {
-    def fromList(config: List[Map[String, String]]): OSParser = OSParser(config.map(OSPattern.fromMap).flatten)
+    def fromList(config: List[Map[String, String]]): OSParser = OSParser(config.flatMap(OSPattern.fromMap))
   }
 }

--- a/src/main/scala/org/uaparser/scala/Parser.scala
+++ b/src/main/scala/org/uaparser/scala/Parser.scala
@@ -2,7 +2,6 @@ package org.uaparser.scala
 
 import java.io.InputStream
 import java.util.{List => JList, Map => JMap}
-
 import org.uaparser.scala.Device.DeviceParser
 import org.uaparser.scala.OS.OSParser
 import org.uaparser.scala.UserAgent.UserAgentParser

--- a/src/main/scala/org/uaparser/scala/Parser.scala
+++ b/src/main/scala/org/uaparser/scala/Parser.scala
@@ -1,11 +1,12 @@
 package org.uaparser.scala
 
 import java.io.InputStream
-import java.util.{ List => JList, Map => JMap }
+import java.util.{List => JList, Map => JMap}
+
 import org.uaparser.scala.Device.DeviceParser
 import org.uaparser.scala.OS.OSParser
 import org.uaparser.scala.UserAgent.UserAgentParser
-import org.yaml.snakeyaml.Yaml
+import org.yaml.snakeyaml.{LoaderOptions, Yaml}
 import org.yaml.snakeyaml.constructor.SafeConstructor
 import scala.collection.JavaConverters._
 import scala.util.Try
@@ -18,8 +19,8 @@ case class Parser(userAgentParser: UserAgentParser, osParser: OSParser, devicePa
 
 object Parser {
   def fromInputStream(source: InputStream): Try[Parser] = Try {
-    val yaml = new Yaml(new SafeConstructor)
-    val javaConfig = yaml.load(source).asInstanceOf[JMap[String, JList[JMap[String, String]]]]
+    val yaml = new Yaml(new SafeConstructor(new LoaderOptions))
+    val javaConfig = yaml.load[JMap[String, JList[JMap[String, String]]]](source)
     val config = javaConfig.asScala.toMap.mapValues(_.asScala.toList.map(_.asScala.toMap.filterNot {
       case (_ , value) => value eq null
     }))

--- a/src/main/scala/org/uaparser/scala/UserAgent.scala
+++ b/src/main/scala/org/uaparser/scala/UserAgent.scala
@@ -46,6 +46,6 @@ object UserAgent {
 
   object UserAgentParser {
     def fromList(config: List[Map[String, String]]): UserAgentParser =
-      UserAgentParser(config.map(UserAgentPattern.fromMap).flatten)
+      UserAgentParser(config.flatMap(UserAgentPattern.fromMap))
   }
 }

--- a/src/test/scala/org/uaparser/scala/ParserSpecBase.scala
+++ b/src/test/scala/org/uaparser/scala/ParserSpecBase.scala
@@ -24,7 +24,7 @@ trait ParserSpecBase extends Specification {
 
     def readCasesConfig(resource: String): List[Map[String, String]] = {
       val stream = this.getClass.getResourceAsStream(resource)
-      val cases = yaml.load(stream).asInstanceOf[JMap[String, JList[JMap[String, String]]]]
+      val cases = yaml.load[JMap[String, JList[JMap[String, String]]]](stream)
         .asScala.toMap.mapValues(_.asScala.toList.map(_.asScala.toMap))
       cases.getOrElse("test_cases", List()).filterNot(_.contains("js_ua")).map { config =>
         config.filterNot { case (_, value) => value eq null }


### PR DESCRIPTION
Just some minor changes: remove things like `dead code` warning, use `flatMap` instead of `map` and `flatten`, and remove the use of the deprecated yaml constructor.