### PR TITLE
Updates scala from 2.13.12 to 2.13.13

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        scala-version: [2.10.7, 2.11.12, 2.12.19, 2.13.12, 3.1.1]
+        scala-version: [2.10.7, 2.11.12, 2.12.19, 2.13.13, 3.1.1]
     steps:
       - name: Checkout repository and submodules
         uses: actions/checkout@v2

--- a/build.sbt
+++ b/build.sbt
@@ -25,8 +25,8 @@ scalacOptions := {
     }
 }
 
-scalaVersion := "2.13.12"
-crossScalaVersions := Seq("2.10.7", "2.11.12", "2.12.19", "2.13.12", "3.1.1")
+scalaVersion := "2.13.13"
+crossScalaVersions := Seq("2.10.7", "2.11.12", "2.12.19", "2.13.13", "3.1.1")
 
 libraryDependencies +=  "org.yaml" % "snakeyaml" % "2.2"
 


### PR DESCRIPTION
Supersedes https://github.com/ua-parser/uap-scala/pull/238. Just updating scala 2.13.