### PR TITLE
Filter out empty strings returned from matching groups

### DIFF
--- a/src/main/scala/org/uaparser/scala/MatcherOps.scala
+++ b/src/main/scala/org/uaparser/scala/MatcherOps.scala
@@ -3,8 +3,18 @@ package org.uaparser.scala
 import java.util.regex.Matcher
 
 object MatcherOps {
-  implicit class MatcherImprovements(val m: Matcher) {
-    import scala.util.control.Exception._
-    def groupAt(i: Int): Option[String] = catching(classOf[IndexOutOfBoundsException]).opt(Option(m.group(i))).flatten
+  implicit class MatcherImprovements(val m: Matcher) extends AnyVal {
+    // Tries to safely return the matching group at index i wrapped in an Option.
+    // We also take care of converting empty strings to a None, because it seems possible in uap-core to define matching
+    // groups that capture empty strings. At the time, the semantics of None and empty strings seemed to match.
+    def groupAt(i: Int): Option[String] = {
+      try {
+        val matched = m.group(i)
+        if (matched == null || matched.isEmpty) None
+        else Some(matched)
+      } catch {
+        case _: IndexOutOfBoundsException => None
+      }
+    }
   }
 }


### PR DESCRIPTION
The motivation for this came from test failures when updating to the latest core.

In particular, the OS parsing and matching groups. For example, the following case (in `test_os.yaml`):

```
APN/1.0 HashiCorp/1.0 Terraform/1.8.1 (+https://www.terraform.io) terraform-provider-aws/4.67.0 (+https://registry.terraform.io/providers/hashicorp/aws) aws-sdk-go-v2/1.18.0 os/macos lang/go/1.19.8 md/GOOS/darwin md/GOARCH/arm64 api/identitystore/1.16.11
```

This user agent is supposed to be parsed to the following OS fields:
```
family: 'Mac OS X'
major:
minor: 
patch: 
patch_minor:
```

Using the following regex:
```
  - regex: 'os\/macos[#]?(\d*)[.]?(\d*)[.]?(\d*)'
    os_replacement: 'Mac OS X'
    os_v1_replacement: '$1'
    os_v2_replacement: '$2'
    os_v3_replacement: '$3'
```

As per https://regex101.com/, this results in:
<img width="283" alt="Screenshot 2025-03-14 at 01 20 03" src="https://github.com/user-attachments/assets/73147c26-4e29-448d-aa9d-7c43261492e9" />

So, we get an error because we are trying to match against `None` in the version fields, but we are replacing with `Some("")`.

So, I think it makes sense to assume empty strings are mapped to Nones. 🤞 


Related to https://github.com/ua-parser/uap-scala/pull/275