### PR TITLE
Upgrade scala 3 version from 3.1.1 to 3.3.5 LTS

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        scala-version: [2.12.20, 2.13.16, 3.1.1]
+        scala-version: [2.12.20, 2.13.16, 3.3.5]
     steps:
       - name: Checkout repository and submodules
         uses: actions/checkout@v2

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "uap-scala"
 organization := "org.uaparser"
 
 scalaVersion := "2.13.14"
-crossScalaVersions := Seq("2.12.20", "2.13.16", "3.1.1")
+crossScalaVersions := Seq("2.12.20", "2.13.16", "3.3.5")
 
 scalacOptions ++= Seq(
   "-Xfatal-warnings",
@@ -38,7 +38,7 @@ libraryDependencies +=  "org.yaml" % "snakeyaml" % "2.4"
 libraryDependencies := {
   CrossVersion.partialVersion(scalaVersion.value) match {
     case Some((3, _)) =>
-      libraryDependencies.value ++ Seq("org.specs2" %% "specs2-core" % "5.0.7" % "test")
+      libraryDependencies.value ++ Seq("org.specs2" %% "specs2-core" % "5.5.8" % "test")
     case Some((2, scalaMajor)) if scalaMajor >= 11 =>
       libraryDependencies.value ++ Seq("org.specs2" %% "specs2-core" % "4.20.9" % "test")
     case _ =>


### PR DESCRIPTION
As titled. Also updates specs2.

Also following the recommendations in https://www.scala-lang.org/development/

> The Scala LTS line is advised to be used for publishing libraries. (Some especially conservative users might also choose it over Scala Next.)
